### PR TITLE
Proxy /courses to courses app

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -14,6 +14,14 @@
     {
       "src": "/bittersweet/(.*)",
       "dest": "/bittersweet/$1"
+    },
+    {
+      "src": "/courses",
+      "dest": "https://dabble-collective-website-fubg.vercel.app/courses"
+    },
+    {
+      "src": "/courses/(.*)",
+      "dest": "https://dabble-collective-website-fubg.vercel.app/courses/"
     }
   ]
-} 
+}


### PR DESCRIPTION
Adds rewrites in root vercel.json to forward /courses to https://dabble-collective-website-fubg.vercel.app/courses.